### PR TITLE
Revert "Redstone-Änderung auf stelle_* ändert nicht mehr Signalstatus"

### DIFF
--- a/programme/stellwerk.lua
+++ b/programme/stellwerk.lua
@@ -643,10 +643,10 @@ local function onRedstoneChange(pc, side, color, state)
     -- Signale
     if type(signale) == "table" then
         for sName, signal in pairs(signale) do
-            pruefeAenderungSignalStellung(sName, signal.hp,  SIGNAL_HP,  pc, side, color, state)
-            pruefeAenderungSignalStellung(sName, signal.sh,  SIGNAL_SH,  pc, side, color, state)
-            pruefeAenderungSignalStellung(sName, signal.za,  SIGNAL_ZA,  pc, side, color, state)
-            pruefeAenderungSignalStellung(sName, signal.ers, SIGNAL_ERS, pc, side, color, state)
+            pruefeAenderungSignalStellung(sName, (signal.hp  or signal.stelle_hp ), SIGNAL_HP,  pc, side, color, state)
+            pruefeAenderungSignalStellung(sName, (signal.sh  or signal.stelle_sh ), SIGNAL_SH,  pc, side, color, state)
+            pruefeAenderungSignalStellung(sName, (signal.za  or signal.stelle_za ), SIGNAL_ZA,  pc, side, color, state)
+            pruefeAenderungSignalStellung(sName, (signal.ers or signal.stelle_ers), SIGNAL_ERS, pc, side, color, state)
         end
     end
     


### PR DESCRIPTION
Reverts DevonFrosch/ESTW-TC#7

Grund: Der Signalstatus wird nicht in der stellwerk.lua selbst geändert, sondern nur, wenn der Client die Änderung auf dem Redstone-Ausgang feststellt.

Eine feste Trennung zwischen Ein- und Ausgängen ist leider nicht möglich.